### PR TITLE
Add multiple morph support and demonstrate possible bug of missing CONTACT_END messages

### DIFF
--- a/sensel-examples/sensel-c/example-2-contacts/src/main.c
+++ b/sensel-examples/sensel-c/example-2-contacts/src/main.c
@@ -25,20 +25,25 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <signal.h>
 #include "sensel.h"
 #include "sensel_device.h"
 
-//The number of times the example should read from the Sensel device
-#define TEST_SCAN_NUM_LOOPS 500
+volatile sig_atomic_t ctrl_c_requested = false;
+
+void handle_ctrl_c(int sig)
+{
+	ctrl_c_requested = true;
+}
 
 int main(int argc, char **argv)
 {
 	//Handle that references a Sensel device
-	SENSEL_HANDLE handle = NULL;
+	SENSEL_HANDLE handle[SENSEL_MAX_DEVICES] = { NULL };
 	//List of all available Sensel devices
 	SenselDeviceList list;
 	//SenselFrame data that will hold the contacts
-	SenselFrameData *frame = NULL;
+	SenselFrameData *frame[SENSEL_MAX_DEVICES] = { NULL };
 
 	//Get a list of avaialble Sensel devices
 	senselGetDeviceList(&list);
@@ -48,34 +53,57 @@ int main(int argc, char **argv)
 		return 0;
 	}
 
-	//Open a Sensel device by the id in the SenselDeviceList, handle initialized 
-	senselOpenDeviceByID(&handle, list.devices[0].idx);
+	signal(SIGINT, handle_ctrl_c);
+	fprintf(stdout, "Press Control-C to stop...\n");
 
-	//Set the frame content to scan contact data
-	senselSetFrameContent(handle, FRAME_CONTENT_CONTACTS_MASK);
-	//Allocate a frame of data, must be done before reading frame data
-	senselAllocateFrameData(handle, &frame);
-	//Start scanning the Sensel device
-	senselStartScanning(handle);
-	for (int c = 0; c < TEST_SCAN_NUM_LOOPS; c++)
-	{
+	//Open all Sensel devices by the id in the SenselDeviceList, handle initialized 
+	for (int i = 0; i < list.num_devices; i++) {
+		senselOpenDeviceByID(&handle[i], list.devices[i].idx);
+
+		//Set the frame content to scan contact data
+		senselSetFrameContent(handle[i], FRAME_CONTENT_CONTACTS_MASK);
+		//Allocate a frame of data, must be done before reading frame data
+		senselAllocateFrameData(handle[i], &frame[i]);
+		//Start scanning the Sensel device
+		senselStartScanning(handle[i]);
+	}
+
+	while (!ctrl_c_requested) {
 		unsigned int num_frames = 0;
 		//Read all available data from the Sensel device
-		senselReadSensor(handle);
-		//Get number of frames available in the data read from the sensor
-		senselGetNumAvailableFrames(handle, &num_frames);
-		for (int f = 0; f < num_frames; f++)
-		{
-			//Read one frame of data
-			senselGetFrame(handle, frame);
-			//Print out contact data
-			fprintf(stdout, "Num Contacts: %d\n", frame->n_contacts);
-            for (int i = 0; i < frame->n_contacts; i++)
-            {
-                fprintf(stdout, "Contact ID: %d\n", frame->contacts[i].id);
-            }
-            fprintf(stdout, "\n");
+		for (int i = 0; i < list.num_devices; i++) {
+			senselReadSensor(handle[i]);
+			//Get number of frames available in the data read from the sensor
+			senselGetNumAvailableFrames(handle[i], &num_frames);
+			for (unsigned int f = 0; f < num_frames; f++)
+			{
+				//Read one frame of data
+				senselGetFrame(handle[i], frame[i]);
+				//Print out contact data
+				if (frame[i]->n_contacts > 0) {
+					fprintf(stdout, "\nNum Contacts: %d\n", frame[i]->n_contacts);
+				}
+				for (int c = 0; c < frame[i]->n_contacts; c++)
+				{
+					unsigned int state = frame[i]->contacts[c].state;
+					char* statestr =
+						state == CONTACT_INVALID ? "CONTACT_INVALID" :
+						state == CONTACT_START ? "CONTACT_START" :
+						state == CONTACT_MOVE ? "CONTACT_MOVE" :
+						state == CONTACT_END ? "CONTACT_END" :
+						"UNKNOWN_CONTACT_STATE";
+					fprintf(stdout, "Contact ID: %d    State: %s\n", frame[i]->contacts[c].id, statestr);
+
+					if (state == CONTACT_START) {
+						senselSetLEDBrightness(handle[i], frame[i]->contacts[c].id, 100);
+					}
+					else if ( state == CONTACT_END ) {
+						senselSetLEDBrightness(handle[i], frame[i]->contacts[c].id, 0);
+					}
+				}
+			}
 		}
+		Sleep(1);
 	}
 	return 0;
 }


### PR DESCRIPTION
This enhances the contacts example to handle multiple Morphs, and
demonstrates a possible bug that causes CONTACT_END messages to be
omitted or lost.  The LEDs are turned on/off when CONTACT_START and
CONTACT_END messages are received.  It also changes it so that it runs
forever, until you hit controlC.  If you run this with 4 Morphs, and tap
one of the Morphs with 3 fingers, quickly, it will often leave one or
more of the LEDS lit.  Looking at the messages that are printed, you can
see that one or more of the contacts doesn't send a CONTACT_END message.
It seems to happen even with 1 Morph connected, so I don't think this
bug is multi-Morph-related, but enhancing this example to handle
multiple Morphs (or creating a new example to handle multiple Morphs)
would be nice to include in the examples, independent of how the bug (if
it is a bug) is fixed.