### PR TITLE
Update Python examples to support Python 2 and 3

### DIFF
--- a/sensel-examples/sensel-python/example_1_hello_sensel.py
+++ b/sensel-examples/sensel-python/example_1_hello_sensel.py
@@ -22,25 +22,24 @@
 # DEALINGS IN THE SOFTWARE.
 ##########################################################################
 
+# Python 3 compatibility
+from __future__ import print_function
+
 import sys
 sys.path.append('../../sensel-lib-wrappers/sensel-lib-python')
 import sensel
-import binascii
 
-if __name__ == "__main__":
-
+if __name__ == '__main__':
     handle = None
-    (error, device_list) = sensel.getDeviceList()
-    if device_list.num_devices != 0:
-        (error, handle) = sensel.openDeviceByID(device_list.devices[0].idx)
-    if handle != None:
-        (error, info) = sensel.getSensorInfo(handle)
+    error, device_list = sensel.getDeviceList()
+    if device_list.num_devices:
+        error, handle = sensel.openDeviceByID(device_list.devices[0].idx)
+    if handle:
+        error, info = sensel.getSensorInfo(handle)
 
-        print "\nSensel Device: "+str(bytearray(device_list.devices[0].serial_num))
-        print "Width: "+str(info.width)+"mm"
-        print "Height: "+str(info.height)+"mm"
-        print "Cols: "+str(info.num_cols)
-        print "Rows: "+str(info.num_rows)
+        print('\nSensel Device: %s' % bytearray(device_list.devices[0].serial_num).decode('utf-8'))
+        print('Width: %smm' % info.width)
+        print('Height: %smm' % info.height)
+        print('Cols: %s' % info.num_cols)
+        print('Rows: %s' % info.num_rows)
         error = sensel.close(handle)
-        raw_input("Press Enter to exit...")
-    


### PR DESCRIPTION
I've updated the Python examples to work with both python 2 and 3. This required a few minor changes:

- Using "input" in Python 3, and including an import that renames "raw_input" for Python 2.
- Importing the print function from `__future__` which makes print behave like in Python 3.

I also applied some minor PEP8 formatting changes, which includes:

- Removing unnecessary brackets
- Reordering imports
- Changing all strings to single quotes

There were a few other really minor changes along the way. If you have any questions about the code, I'd be happy to explain anything. I tested this with my Sensel Morph on the Mac's built-in python (2.7.10) as well as 3.6.